### PR TITLE
feat: add deterministic M5 forecasting and procurement stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ For privacy and licensing reasons these files are **not included** in this repos
 
 2. Download the three M5 dataset files from Kaggle and place them in the `data/` folder.
 
+   ```text
+   data/
+   ├── sales_train_validation.csv
+   ├── sell_prices.csv
+   └── calendar.csv
+   ```
+
+   The service validates that each file exists before serving forecasts or procurement guidance.
+
 3. Copy `.env.example` to `.env` and fill in your configuration, especially your `GEMINI_API_KEY` if you plan to use the optional LLM features.
 
 4. Build and run the backend locally using Docker Compose:
@@ -86,6 +95,19 @@ For privacy and licensing reasons these files are **not included** in this repos
    This will start the FastAPI backend on `http://localhost:8000` and the Streamlit UI on `http://localhost:8501`.
 
 5. Navigate to the Streamlit UI to explore forecasts and procurement recommendations.
+
+6. (Optional) Run the backend unit tests locally to verify the deterministic forecasting and procurement guardrails:
+
+   ```bash
+   poetry run pytest backend/tests
+   ```
+
+   The tests use lightweight synthetic M5 extracts so they execute quickly without the full dataset.
+
+### Configuration quick reference
+
+- `configs/settings.yaml` — operational context such as `service_level_target`, `lead_time_days`, `carrying_cost_rate`, `order_cost` and `gross_margin_rate`. These values feed directly into the EOQ/ROP calculations.
+- `configs/thresholds.yaml` — guardrails including `auto_approval_limit`, `min_service_level`, `gmroi_min` and `max_cash_outlay`. Recommendations that breach these thresholds are flagged for manual approval in the UI.
 
 ## Design philosophy
 

--- a/backend/app/api/v1/forecasts.py
+++ b/backend/app/api/v1/forecasts.py
@@ -1,39 +1,26 @@
-"""
-Routes for demand forecasting.
+"""Routes for demand forecasting."""
 
-Clients may request a forecast for a given SKU identifier.  The horizon
-parameter determines how many days ahead to predict.  Forecasts are
-returned as a list of data points including mean demand and prediction
-intervals.
-"""
+from fastapi import APIRouter, HTTPException, Query, status
 
-from fastapi import APIRouter, HTTPException
-from typing import List
-
-from ..services.forecasting_service import ForecastingService, ForecastPoint, ForecastResponse
+from ..services.forecasting_service import ForecastingService, ForecastResponse
 
 router = APIRouter()
 
-# Create a single forecasting service instance.  In a more complex application
-# you might use dependency injection to provide this per-request.
 _forecast_service = ForecastingService(data_root="data")
 
 
 @router.get("/forecasts/{sku_id}", response_model=ForecastResponse)
-async def get_forecast(sku_id: str, horizon_days: int = 28) -> ForecastResponse:
-    """Return a forecast for the specified SKU.
+async def get_forecast(
+    sku_id: str,
+    horizon_days: int = Query(28, ge=1, le=365, description="Forecast horizon in days"),
+) -> ForecastResponse:
+    """Return a forecast for the specified SKU."""
 
-    Args:
-        sku_id: The item identifier from the M5 dataset (e.g. "HOBBIES_1_001").
-        horizon_days: Number of future days to forecast (default: 28).
-
-    Returns:
-        A ``ForecastResponse`` containing the predicted demand and prediction
-        intervals for each day in the horizon.
-    """
     try:
-        return _forecast_service.forecast(sku_id=sku_id, horizon_days=horizon_days)
-    except FileNotFoundError as e:
-        raise HTTPException(status_code=500, detail=str(e))
-    except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        return _forecast_service.forecast(sku_id=sku_id, horizon_days=int(horizon_days))
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except ValueError as exc:
+        message = str(exc)
+        status_code = status.HTTP_404_NOT_FOUND if "SKU" in message else status.HTTP_400_BAD_REQUEST
+        raise HTTPException(status_code=status_code, detail=message) from exc

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -9,9 +9,26 @@ containing business rules and thresholds.
 from __future__ import annotations
 
 import os
-import yaml
 from functools import lru_cache
-from pydantic import BaseSettings
+
+import yaml
+
+try:  # pragma: no cover - import compatibility shim
+    from pydantic_settings import BaseSettings  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    try:
+        from pydantic import BaseSettings  # type: ignore
+    except Exception:  # pragma: no cover
+        class BaseSettings:  # type: ignore[override]
+            """Fallback BaseSettings implementation for tests.
+
+            The minimal implementation stores provided keyword arguments as
+            attributes and ignores environment variable loading.
+            """
+
+            def __init__(self, **data: object) -> None:
+                for key, value in data.items():
+                    setattr(self, key, value)
 
 
 class Settings(BaseSettings):

--- a/backend/app/services/forecasting_service.py
+++ b/backend/app/services/forecasting_service.py
@@ -1,109 +1,183 @@
-"""
-Forecasting service using the M5 dataset.
+"""Demand forecasting service based on the M5 dataset.
 
-This service reads the M5 sales and calendar files from the ``data/`` directory
-and provides a naive demand forecast for a given SKU.  The current
-implementation uses a simple moving average of recent demand as a
-placeholder; you can replace this with Prophet, XGBoost or any other
-model as required.  The forecast is returned as a ``ForecastResponse``
-containing a list of ``ForecastPoint`` instances.
+The implementation intentionally favours deterministic, lightweight
+algorithms so that the API remains responsive even in restricted
+execution environments.  A smoothed moving‑average baseline is used to
+project demand for the requested horizon.  Prediction intervals are
+derived from recent variability and aligned with the official M5
+calendar to guarantee that forecast dates are valid.
 """
 
 from __future__ import annotations
 
+import logging
 import os
-from datetime import datetime, timedelta
-from typing import List
+from datetime import date
+from typing import Iterable, List
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 
 from ..models.schemas import ForecastPoint, ForecastResponse
 
+LOGGER = logging.getLogger(__name__)
+
 
 class ForecastingService:
-    def __init__(self, data_root: str = "data") -> None:
+    """Generate per‑SKU forecasts from the M5 sales history."""
+
+    def __init__(self, data_root: str = "data", moving_average_window: int = 28) -> None:
         self.data_root = data_root
+        self.moving_average_window = moving_average_window
         self.sales_df: pd.DataFrame | None = None
         self.calendar_df: pd.DataFrame | None = None
         self._load_data()
 
+    # ------------------------------------------------------------------
     def _load_data(self) -> None:
-        """Load sales and calendar data from CSV files.
+        """Load the required CSV files into memory.
 
-        If the files are missing, the corresponding data frames are left as
-        ``None``.  An exception will be raised later when forecasting is
-        requested without data.
+        The files are read once at service initialisation and cached for
+        subsequent requests.  Missing files are tolerated here so that we
+        can raise a user‑friendly error when a forecast is requested.
         """
-        sales_path = os.path.join(self.data_root, "sales_train_validation.csv")
-        cal_path = os.path.join(self.data_root, "calendar.csv")
-        if os.path.exists(sales_path):
-            self.sales_df = pd.read_csv(sales_path)
-        if os.path.exists(cal_path):
-            self.calendar_df = pd.read_csv(cal_path)
 
+        sales_path = os.path.join(self.data_root, "sales_train_validation.csv")
+        calendar_path = os.path.join(self.data_root, "calendar.csv")
+
+        if os.path.exists(sales_path):
+            try:
+                self.sales_df = pd.read_csv(sales_path)
+            except Exception as exc:  # pragma: no cover - defensive branch
+                LOGGER.exception("Failed to load sales dataset at %s", sales_path)
+                raise FileNotFoundError(
+                    "Unable to load sales_train_validation.csv; please verify the file integrity."
+                ) from exc
+
+        if os.path.exists(calendar_path):
+            try:
+                calendar_df = pd.read_csv(calendar_path)
+                calendar_df["date"] = pd.to_datetime(calendar_df["date"], format="%Y-%m-%d")
+                self.calendar_df = calendar_df
+            except Exception as exc:  # pragma: no cover - defensive branch
+                LOGGER.exception("Failed to load calendar dataset at %s", calendar_path)
+                raise FileNotFoundError(
+                    "Unable to load calendar.csv; please verify the file integrity."
+                ) from exc
+
+    # ------------------------------------------------------------------
     def _ensure_loaded(self) -> None:
-        """Ensure that the required datasets are loaded."""
         if self.sales_df is None or self.calendar_df is None:
             raise FileNotFoundError(
-                "Required dataset files (sales_train_validation.csv and calendar.csv) are missing from the data directory."
+                "M5 dataset files were not found. Expected sales_train_validation.csv and calendar.csv under the data/ directory."
             )
 
+    # ------------------------------------------------------------------
+    def _get_sku_timeseries(self, sku_id: str) -> pd.Series:
+        assert self.sales_df is not None
+        sku_rows = self.sales_df[self.sales_df["item_id"] == sku_id]
+        if sku_rows.empty:
+            raise ValueError(f"SKU '{sku_id}' was not found in the sales dataset")
+
+        demand_cols = [col for col in sku_rows.columns if col.startswith("d_")]
+        if not demand_cols:
+            raise ValueError(f"No demand history found for SKU '{sku_id}'")
+
+        demand_series = sku_rows[demand_cols].sum(axis=0)
+        demand_series.index = demand_cols
+        return demand_series
+
+    # ------------------------------------------------------------------
+    def _map_days_to_dates(self, days: Iterable[str]) -> List[date]:
+        assert self.calendar_df is not None
+        calendar_map = dict(zip(self.calendar_df["d"], self.calendar_df["date"]))
+        try:
+            return [pd.to_datetime(calendar_map[d]).date() for d in days]
+        except KeyError as exc:
+            raise ValueError(f"Calendar is missing entries for day '{exc.args[0]}'") from exc
+
+    # ------------------------------------------------------------------
+    def _future_dates(self, last_day: str, horizon_days: int) -> List[date]:
+        assert self.calendar_df is not None
+        calendar_df = self.calendar_df
+        try:
+            last_idx = calendar_df.index[calendar_df["d"] == last_day][0]
+        except IndexError as exc:
+            raise ValueError(f"Calendar does not contain the last observed day '{last_day}'") from exc
+
+        future_slice = calendar_df.iloc[last_idx + 1 : last_idx + 1 + horizon_days]
+        if len(future_slice) < horizon_days:
+            raise ValueError(
+                "Requested horizon exceeds available calendar dates. Reduce horizon_days or provide extended calendar data."
+            )
+        return [d.date() for d in future_slice["date"]]
+
+    # ------------------------------------------------------------------
     def forecast(self, sku_id: str, horizon_days: int = 28) -> ForecastResponse:
-        """Compute a naive forecast for the given SKU.
+        """Return a per‑day forecast for the requested SKU.
 
-        Args:
-            sku_id: The item identifier from the M5 dataset.
-            horizon_days: Number of days to forecast ahead.
-
-        Returns:
-            A ``ForecastResponse`` containing the forecast points.
-
-        Raises:
-            FileNotFoundError: If the dataset CSV files are not available.
-            ValueError: If the SKU is not found in the sales dataset.
+        The routine relies solely on the historical sales for the SKU and
+        generates a smoothed moving average baseline along with a simple
+        prediction interval.  The interval width is determined from the
+        recent coefficient of variation to provide a sensible guardrail
+        for downstream services.
         """
+
+        if horizon_days <= 0:
+            raise ValueError("horizon_days must be a positive integer")
+
         self._ensure_loaded()
         assert self.sales_df is not None and self.calendar_df is not None
 
-        # Filter sales records for the requested SKU
-        sku_rows = self.sales_df[self.sales_df["item_id"] == sku_id]
-        if sku_rows.empty:
-            raise ValueError(f"SKU '{sku_id}' not found in sales dataset")
+        demand_series = self._get_sku_timeseries(sku_id)
+        dates = self._map_days_to_dates(demand_series.index)
+        history = pd.Series(demand_series.values, index=pd.DatetimeIndex(dates, name="date"))
+        history = history.sort_index()
 
-        # Identify demand columns (d_1, d_2, …)
-        demand_cols = [col for col in sku_rows.columns if col.startswith("d_")]
-        # Sum demand across all stores for this SKU
-        demand_series = sku_rows[demand_cols].sum(axis=0)
-        # Map day indices to dates using the calendar file
-        # The calendar file has columns: d, date, weekday, etc.
-        day_to_date = dict(zip(self.calendar_df["d"], pd.to_datetime(self.calendar_df["date"])))
-        # Build a time series DataFrame
-        ts = pd.DataFrame({
-            "date": [day_to_date[d] for d in demand_cols],
-            "value": demand_series.values,
-        }).sort_values("date")
+        window = min(self.moving_average_window, len(history))
+        if window == 0:
+            raise ValueError(f"SKU '{sku_id}' does not have sufficient history to forecast")
 
-        # Compute a simple moving average as the point forecast
-        window = min(14, len(ts))  # window length: last 14 days or entire series
-        last_mean = float(ts["value"].tail(window).mean()) if window > 0 else 0.0
-        # Provide a constant forecast for the horizon
-        start_date = ts["date"].iloc[-1] + timedelta(days=1)
-        forecast_dates = [start_date + timedelta(days=i) for i in range(horizon_days)]
-        # Use ±10% interval and fixed confidence for demonstration
-        points: List[ForecastPoint] = []
-        for date_point in forecast_dates:
-            mean = last_mean
-            lo = mean * 0.9
-            hi = mean * 1.1
-            points.append(
-                ForecastPoint(
-                    date=date_point.date(),
-                    mean=mean,
-                    lo=lo,
-                    hi=hi,
-                    model="naive",
-                    confidence=0.5,
-                )
+        recent = history.iloc[-window:]
+        mean_forecast = float(recent.mean())
+        # Estimate variability: use rolling std, fall back to poisson like sqrt(mean)
+        std_estimate = float(recent.std(ddof=1)) if len(recent) > 1 else float(np.sqrt(max(mean_forecast, 1.0)))
+        if std_estimate == 0.0:
+            std_estimate = float(np.sqrt(max(mean_forecast, 1.0)))
+
+        LOGGER.info(
+            "Forecasting SKU %s using SMA window=%s (mean=%.2f, std=%.2f, horizon=%s)",
+            sku_id,
+            window,
+            mean_forecast,
+            std_estimate,
+            horizon_days,
+        )
+
+        future_dates = self._future_dates(demand_series.index[-1], horizon_days)
+
+        # 80% interval (z ≈ 1.28155)
+        z_score = 1.28155
+        lo_val = max(mean_forecast - z_score * std_estimate, 0.0)
+        hi_val = mean_forecast + z_score * std_estimate
+
+        # Confidence scaled between 0.3 and 0.95 based on coefficient of variation
+        coeff_var = std_estimate / mean_forecast if mean_forecast else float("inf")
+        if np.isinf(coeff_var):
+            confidence = 0.3
+        else:
+            confidence = float(max(0.3, min(0.95, 1.0 / (1.0 + coeff_var))))
+
+        points: List[ForecastPoint] = [
+            ForecastPoint(
+                date=forecast_date,
+                mean=round(mean_forecast, 4),
+                lo=round(lo_val, 4),
+                hi=round(hi_val, 4),
+                model="sma",
+                confidence=round(confidence, 4),
             )
+            for forecast_date in future_dates
+        ]
+
         return ForecastResponse(sku_id=sku_id, horizon_days=horizon_days, forecast=points)

--- a/backend/app/services/inventory_service.py
+++ b/backend/app/services/inventory_service.py
@@ -1,58 +1,125 @@
-"""
-Service to manage inventory state and SKU metadata.
-
-This service provides helper methods to look up SKU information and
-inventory levels.  In a real system this might connect to an ERP or
-database; here we derive some information from the M5 dataset when
-available.  If the dataset is not present, stub values are returned.
-"""
+"""Inventory helper utilities built on top of the M5 dataset."""
 
 from __future__ import annotations
 
+import logging
 import os
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any, Dict, Optional
+
 import pandas as pd
-from typing import Optional, Dict, Any
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SKUPrice:
+    """Lightweight container for SKU price metadata."""
+
+    item_id: str
+    store_id: Optional[str]
+    sell_price: float
+    week: Optional[int]
 
 
 class InventoryService:
+    """Provide SKU metadata, unit cost estimates and inventory placeholders."""
+
     def __init__(self, data_root: str = "data") -> None:
         self.data_root = data_root
         self.sales_df: Optional[pd.DataFrame] = None
+        self.prices_df: Optional[pd.DataFrame] = None
         self._load()
 
+    # ------------------------------------------------------------------
     def _load(self) -> None:
-        """Attempt to load the sales dataset to extract SKU metadata."""
-        path = os.path.join(self.data_root, "sales_train_validation.csv")
-        if os.path.exists(path):
+        sales_path = os.path.join(self.data_root, "sales_train_validation.csv")
+        prices_path = os.path.join(self.data_root, "sell_prices.csv")
+
+        if os.path.exists(sales_path):
             try:
-                self.sales_df = pd.read_csv(path)
-            except Exception:
+                self.sales_df = pd.read_csv(sales_path)
+            except Exception as exc:  # pragma: no cover - defensive logging only
+                LOGGER.warning("Unable to load sales dataset at %s: %s", sales_path, exc)
                 self.sales_df = None
 
-    def get_sku_info(self, sku_id: str) -> Dict[str, Any]:
-        """Return basic metadata for a SKU.
+        if os.path.exists(prices_path):
+            try:
+                self.prices_df = pd.read_csv(prices_path)
+            except Exception as exc:  # pragma: no cover - defensive logging only
+                LOGGER.warning("Unable to load sell prices dataset at %s: %s", prices_path, exc)
+                self.prices_df = None
 
-        Currently this returns the department and category identifiers from
-        the sales dataset if available.  Otherwise it returns an empty
-        dictionary.
-        """
+    # ------------------------------------------------------------------
+    def sku_exists(self, sku_id: str) -> bool:
+        return bool(self.sales_df is not None and not self.sales_df[self.sales_df["item_id"] == sku_id].empty)
+
+    # ------------------------------------------------------------------
+    def get_sku_info(self, sku_id: str) -> Dict[str, Any]:
         if self.sales_df is None:
             return {}
         row = self.sales_df[self.sales_df["item_id"] == sku_id]
         if row.empty:
             return {}
-        # Take the first matching record
         rec = row.iloc[0]
         return {
             "dept_id": rec.get("dept_id"),
             "cat_id": rec.get("cat_id"),
             "store_id": rec.get("store_id"),
+            "state_id": rec.get("state_id"),
         }
 
+    # ------------------------------------------------------------------
     def get_current_inventory(self, sku_id: str) -> int:
-        """Return the current on‑hand inventory level for a SKU.
+        """Return stub on‑hand inventory levels.
 
-        In a real system this would query an inventory database; here it
-        always returns zero because we don't track inventory balances.
+        In production this would connect to an inventory store.  For the M5
+        dataset we do not have stock balances so a conservative placeholder
+        of ``0`` is returned.
         """
+
         return 0
+
+    # ------------------------------------------------------------------
+    @lru_cache(maxsize=1024)
+    def get_latest_price(self, sku_id: str) -> Optional[SKUPrice]:
+        """Return the most recent sell price for the SKU.
+
+        Sell prices in the M5 dataset are weekly and store specific.  We take
+        the latest known price across all stores and return it as a proxy for
+        unit cost.
+        """
+
+        if self.prices_df is None:
+            return None
+
+        sku_prices = self.prices_df[self.prices_df["item_id"] == sku_id]
+        if sku_prices.empty:
+            return None
+
+        latest = sku_prices.sort_values("wm_yr_wk").iloc[-1]
+        return SKUPrice(
+            item_id=sku_id,
+            store_id=latest.get("store_id"),
+            sell_price=float(latest.get("sell_price", 0.0)),
+            week=int(latest.get("wm_yr_wk")) if not pd.isna(latest.get("wm_yr_wk")) else None,
+        )
+
+    # ------------------------------------------------------------------
+    def estimate_unit_cost(self, sku_id: str) -> float:
+        """Estimate the per‑unit acquisition cost for a SKU.
+
+        Without procurement cost data we fall back to the latest known sell
+        price as a proxy.  If pricing data is missing we return ``1.0`` to
+        keep downstream economic calculations finite.
+        """
+
+        price = self.get_latest_price(sku_id)
+        if price is None or price.sell_price <= 0:
+            return 1.0
+        # Treat sell price as a margin‑inclusive figure; assume a modest 25%
+        # gross margin to back into an approximate unit cost.
+        assumed_margin = 0.25
+        unit_cost = price.sell_price * (1 - assumed_margin)
+        return max(unit_cost, 0.5)

--- a/backend/app/services/procurement_service.py
+++ b/backend/app/services/procurement_service.py
@@ -1,69 +1,157 @@
-"""
-Service responsible for generating procurement recommendations.
-
-This module computes reorder quantities and points based on forecast data and
-business guardrails.  For demonstration purposes it implements a very
-simple calculation: reorder enough to cover a week of forecast demand
-plus a safety margin, and multiply by a factor to determine the order
-quantity.  The recommendation includes a confidence score and whether
-human approval is required based on configured spending thresholds.
-"""
+"""Generate procurement recommendations using EOQ/ROP logic."""
 
 from __future__ import annotations
 
+import logging
+import math
 import os
-from typing import List, Dict, Any
+from statistics import mean
+from typing import Any, Dict, List
+
 import numpy as np
 
-from ..models.schemas import ForecastResponse, ReorderRec
 from ..core.config import load_yaml
+from ..models.schemas import ForecastResponse, ReorderRec
+from .inventory_service import InventoryService
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _z_value_for_service_level(service_level: float) -> float:
+    """Return the z-score for a one-sided service level using erfcinv."""
+
+    service_level = max(0.5, min(service_level, 0.999))
+    try:
+        from math import erfcinv, sqrt
+
+        return sqrt(2.0) * erfcinv(2.0 * (1.0 - service_level))
+    except Exception:  # pragma: no cover - erfcinv unavailable in some interpreters
+        # Fallback mapping for common levels (rounded)
+        lookup = {
+            0.9: 1.2816,
+            0.95: 1.6449,
+            0.97: 1.8808,
+            0.98: 2.0537,
+            0.99: 2.3263,
+        }
+        closest = min(lookup.keys(), key=lambda x: abs(x - service_level))
+        return lookup[closest]
 
 
 class ProcurementService:
-    def __init__(self, config_root: str = "configs") -> None:
-        """Load threshold configuration from YAML files."""
+    """EOQ/ROP based recommendation engine."""
+
+    def __init__(
+        self,
+        config_root: str = "configs",
+        inventory_service: InventoryService | None = None,
+    ) -> None:
         thresholds_path = os.path.join(config_root, "thresholds.yaml")
+        settings_path = os.path.join(config_root, "settings.yaml")
+
         thresholds = load_yaml(thresholds_path)
-        # Set defaults if keys are missing
-        self.auto_approval_limit = float(thresholds.get("auto_approval_limit", 1000))
+        settings = load_yaml(settings_path)
+
+        self.auto_approval_limit = float(thresholds.get("auto_approval_limit", 1_000.0))
         self.min_service_level = float(thresholds.get("min_service_level", 0.9))
-        self.min_gmroi_delta = float(thresholds.get("min_gmroi_delta", 0.05))
-        self.max_cash_outlay = float(thresholds.get("max_cash_outlay", 10000))
+        self.gmroi_min = float(thresholds.get("gmroi_min", 1.0))
+        self.max_cash_outlay = float(thresholds.get("max_cash_outlay", 10_000.0))
 
+        self.carrying_cost_rate = float(settings.get("carrying_cost_rate", 0.20))
+        self.service_level_target = float(settings.get("service_level_target", settings.get("default_service_level", 0.95)))
+        self.default_lead_time_days = float(settings.get("lead_time_days", 7))
+        self.default_order_cost = float(settings.get("order_cost", 75.0))
+        self.default_margin_rate = float(settings.get("gross_margin_rate", 0.30))
+
+        self.inventory_service = inventory_service or InventoryService()
+
+    # ------------------------------------------------------------------
+    def _derive_daily_stats(self, forecast: ForecastResponse) -> tuple[float, float, float]:
+        means = np.array([max(pt.mean, 0.0) for pt in forecast.forecast], dtype=float)
+        confidences = [pt.confidence for pt in forecast.forecast]
+        interval_spreads = np.array(
+            [max(pt.hi - pt.lo, 0.0) for pt in forecast.forecast],
+            dtype=float,
+        )
+
+        if means.size == 0:
+            return 0.0, 0.0, 0.0
+
+        daily_mean = float(np.mean(means))
+        # Convert interval width (approx 80% interval) to std: width ≈ 2*z*std
+        # using the same z as forecasting service (1.28155) -> std ≈ width / (2*z)
+        z_interval = 1.28155
+        derived_stds = interval_spreads / max(2.0 * z_interval, 1e-6)
+        daily_std = float(np.mean(derived_stds)) if np.any(interval_spreads) else float(np.std(means))
+        avg_conf = float(mean(confidences)) if confidences else 0.0
+        return daily_mean, max(daily_std, 0.0), avg_conf
+
+    # ------------------------------------------------------------------
     def recommend(self, forecast: ForecastResponse, context: Dict[str, Any]) -> List[ReorderRec]:
-        """Generate a reorder recommendation from forecast data.
+        if not forecast.forecast:
+            LOGGER.warning("Forecast for SKU %s is empty; no recommendation generated", forecast.sku_id)
+            return []
 
-        Args:
-            forecast: The demand forecast for a SKU.
-            context: Additional business context (unused in this demo).
+        daily_mean, daily_std, avg_conf = self._derive_daily_stats(forecast)
+        lead_time_days = float(context.get("lead_time_days", self.default_lead_time_days))
+        if lead_time_days <= 0:
+            lead_time_days = self.default_lead_time_days
 
-        Returns:
-            A list containing a single ``ReorderRec``.
-        """
-        # Calculate expected demand over the horizon
-        demand_values = [point.mean for point in forecast.forecast]
-        if not demand_values:
-            reorder_point = 0
+        service_level = float(context.get("service_level_target", self.service_level_target))
+        z_val = _z_value_for_service_level(service_level)
+        safety_stock = z_val * daily_std * math.sqrt(lead_time_days)
+        reorder_point = int(round(daily_mean * lead_time_days + safety_stock))
+
+        unit_cost = float(context.get("unit_cost", self.inventory_service.estimate_unit_cost(forecast.sku_id)))
+        order_cost = float(context.get("order_cost", self.default_order_cost))
+        carrying_cost = unit_cost * self.carrying_cost_rate
+
+        annual_demand = daily_mean * 365.0
+        if annual_demand <= 0 or carrying_cost <= 0:
+            eoq = 0.0
         else:
-            # Use one week of demand as reorder point
-            reorder_point = int(np.mean(demand_values[:7]) * 7)
-        # Order enough to cover two reorder points
-        order_qty = max(reorder_point * 2, 1)
-        # Compute a simple GMROI delta: encourage orders only if demand is positive
-        gmroi_delta = 0.1 if reorder_point > 0 else 0.0
-        # Confidence is based on the average forecast confidence
-        confidences = [point.confidence for point in forecast.forecast]
-        avg_conf = float(np.mean(confidences)) if confidences else 0.0
-        # Determine whether human approval is required: if the order's notional cost exceeds the auto approval limit
-        # Since we do not know unit price, treat quantity as a proxy for cost
-        requires_approval = order_qty > self.auto_approval_limit
+            eoq = math.sqrt((2.0 * annual_demand * order_cost) / carrying_cost)
+
+        order_qty = int(max(round(eoq), 0))
+        if order_qty == 0 and daily_mean > 0:
+            order_qty = max(int(round(daily_mean * lead_time_days)), 1)
+
+        total_spend = order_qty * unit_cost
+        gross_margin_rate = float(context.get("gross_margin_rate", self.default_margin_rate))
+        expected_gmroi = (gross_margin_rate * unit_cost) / max(carrying_cost, 1e-6)
+        gmroi_delta = expected_gmroi - self.gmroi_min
+
+        requires_approval = (
+            total_spend > self.auto_approval_limit
+            or service_level < self.min_service_level
+            or gmroi_delta < 0
+            or total_spend > self.max_cash_outlay
+        )
+
+        # Confidence penalises variability and approval overrides
+        variability_penalty = 1.0 / (1.0 + (daily_std / (daily_mean + 1e-6))) if daily_mean else 0.3
+        confidence = float(max(0.1, min(0.99, avg_conf * variability_penalty)))
+        if requires_approval:
+            confidence = min(confidence, 0.6)
+
+        LOGGER.info(
+            "Procurement rec for %s: mean=%.2f std=%.2f lead=%.1f order_qty=%s spend=%.2f gmroi_delta=%.2f",
+            forecast.sku_id,
+            daily_mean,
+            daily_std,
+            lead_time_days,
+            order_qty,
+            total_spend,
+            gmroi_delta,
+        )
+
         return [
             ReorderRec(
                 sku_id=forecast.sku_id,
-                reorder_point=reorder_point,
-                order_qty=order_qty,
-                gmroi_delta=gmroi_delta,
-                confidence=avg_conf,
+                reorder_point=max(reorder_point, 0),
+                order_qty=max(order_qty, 0),
+                gmroi_delta=round(gmroi_delta, 4),
+                confidence=round(confidence, 4),
                 requires_approval=requires_approval,
             )
         ]

--- a/backend/tests/test_forecasting.py
+++ b/backend/tests/test_forecasting.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+import pandas as pd
+
+from backend.app.services.forecasting_service import ForecastingService
+
+
+def _write_m5_stub(tmp_path: Path) -> None:
+    sales = pd.DataFrame(
+        {
+            "id": ["ITEM_1_store"],
+            "item_id": ["ITEM_1"],
+            "dept_id": ["FOODS"],
+            "cat_id": ["FOODS"],
+            "store_id": ["CA_1"],
+            "state_id": ["CA"],
+            **{f"d_{i}": [10 + i % 3] for i in range(1, 11)},
+        }
+    )
+    calendar = pd.DataFrame(
+        {
+            "date": pd.date_range("2020-01-01", periods=15, freq="D"),
+            "d": [f"d_{i}" for i in range(1, 16)],
+        }
+    )
+    sales.to_csv(tmp_path / "sales_train_validation.csv", index=False)
+    calendar.to_csv(tmp_path / "calendar.csv", index=False)
+
+
+def test_forecast_returns_expected_horizon(tmp_path: Path) -> None:
+    _write_m5_stub(tmp_path)
+    service = ForecastingService(data_root=str(tmp_path), moving_average_window=5)
+
+    result = service.forecast("ITEM_1", horizon_days=3)
+
+    assert result.sku_id == "ITEM_1"
+    assert result.horizon_days == 3
+    assert len(result.forecast) == 3
+    dates = [point.date for point in result.forecast]
+    assert dates == sorted(dates), "Forecast dates should be strictly increasing"
+    assert all(point.model == "sma" for point in result.forecast)
+    assert all(point.lo <= point.mean <= point.hi for point in result.forecast)

--- a/backend/tests/test_procurement.py
+++ b/backend/tests/test_procurement.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+import sys
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from backend.app.models.schemas import ForecastPoint, ForecastResponse
+from backend.app.services.procurement_service import ProcurementService
+
+
+class StubInventoryService:
+    def estimate_unit_cost(self, sku_id: str) -> float:  # pragma: no cover - trivial
+        return 25.0
+
+
+def _write_configs(tmp_path: Path) -> Path:
+    config_root = tmp_path / "cfg"
+    config_root.mkdir()
+    thresholds = {
+        "auto_approval_limit": 100.0,
+        "min_service_level": 0.85,
+        "gmroi_min": 1.0,
+        "max_cash_outlay": 10_000.0,
+    }
+    settings = {
+        "carrying_cost_rate": 0.25,
+        "service_level_target": 0.9,
+        "lead_time_days": 7,
+        "order_cost": 50.0,
+        "gross_margin_rate": 0.3,
+    }
+    (config_root / "thresholds.yaml").write_text(yaml.safe_dump(thresholds))
+    (config_root / "settings.yaml").write_text(yaml.safe_dump(settings))
+    return config_root
+
+
+def _build_forecast(horizon: int = 14) -> ForecastResponse:
+    start = date(2020, 1, 1)
+    points = []
+    for i in range(horizon):
+        day = start + timedelta(days=i)
+        points.append(
+            ForecastPoint(
+                date=day,
+                mean=20.0,
+                lo=16.0,
+                hi=24.0,
+                model="sma",
+                confidence=0.7,
+            )
+        )
+    return ForecastResponse(sku_id="ITEM_1", horizon_days=horizon, forecast=points)
+
+
+def test_requires_approval_when_spend_exceeds_limit(tmp_path: Path) -> None:
+    config_root = _write_configs(tmp_path)
+    service = ProcurementService(config_root=str(config_root), inventory_service=StubInventoryService())
+    forecast = _build_forecast()
+
+    recs = service.recommend(forecast, context={})
+
+    assert len(recs) == 1
+    recommendation = recs[0]
+    assert recommendation.order_qty > 0
+    assert recommendation.requires_approval is True
+    assert recommendation.confidence <= 0.6

--- a/configs/settings.yaml
+++ b/configs/settings.yaml
@@ -7,7 +7,11 @@
 
 environment: "development"
 default_service_level: 0.95  # desired probability of not stocking out
+service_level_target: 0.96   # explicit service level target used in procurement logic
 lead_time_days: 7           # typical supplier lead time in days
+carrying_cost_rate: 0.22    # holding cost as a fraction of unit cost per year
+order_cost: 75.0            # administrative + transport cost per order
+gross_margin_rate: 0.30     # expected gross margin percentage per SKU
 
 # External feeds: these can be used to incorporate knowledge of disruptions
 disruption_feeds:

--- a/configs/thresholds.yaml
+++ b/configs/thresholds.yaml
@@ -5,5 +5,5 @@
 
 auto_approval_limit: 1000    # Maximum spend (in your currency) that can be auto‑approved
 min_service_level: 0.90      # Minimum acceptable fill rate; below this triggers overrides
-min_gmroi_delta: 0.05        # Minimum expected improvement in GMROI to justify a purchase
+gmroi_min: 1.10              # Minimum GMROI required for automatic approval
 max_cash_outlay: 10000       # Maximum available cash for inventory purchases per cycle

--- a/frontend/pages/2_Forecasts.py
+++ b/frontend/pages/2_Forecasts.py
@@ -1,54 +1,69 @@
-"""
-Forecasts page for viewing and adjusting SKU demand forecasts.
+"""Streamlit page for per-SKU demand forecasts."""
 
-Users can select a SKU and forecast horizon, view the predicted demand
-and adjust the forecast manually if needed.  Adjustments are for
-visualisation only; they are not persisted in the backend.
-"""
+from __future__ import annotations
 
 import os
+from typing import Any, Dict
+
+import altair as alt
+import pandas as pd
 import requests
 import streamlit as st
-import pandas as pd
-import altair as alt
 
 API_URL = os.getenv("API_URL", "http://localhost:8000/api/v1")
 
-st.title("🔮 Forecasts")
 
-st.write(
-    "Retrieve demand forecasts for a given SKU.  You can adjust the forecast "
-    "values to explore different scenarios; these adjustments are not saved "
-    "but help you understand potential impacts."
-)
+def _fetch_forecast(sku: str, horizon: int) -> Dict[str, Any]:
+    response = requests.get(
+        f"{API_URL}/forecasts/{sku}",
+        params={"horizon_days": horizon},
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+st.title("🔮 Forecasts")
+st.caption("Visualise deterministic forecasts generated from the Walmart M5 dataset.")
 
 with st.form(key="forecast_form"):
-    sku = st.text_input("SKU ID", value="HOBBIES_1_001")
-    horizon = st.number_input("Horizon (days)", min_value=1, max_value=90, value=28, step=1)
+    sku = st.text_input("SKU ID", value="HOBBIES_1_001", help="Enter an M5 item_id value, e.g. FOODS_3_090")
+    horizon = st.number_input("Horizon (days)", min_value=7, max_value=90, value=28, step=1)
     submitted = st.form_submit_button("Get forecast")
 
 if submitted:
     try:
-        with st.spinner("Fetching forecast…"):
-            resp = requests.get(f"{API_URL}/forecasts/{sku}", params={"horizon_days": horizon}, timeout=30)
-            resp.raise_for_status()
-            data = resp.json()
-        df = pd.DataFrame(data["forecast"])
-        df["date"] = pd.to_datetime(df["date"])
-        df["adjusted_mean"] = df["mean"]  # start with original values
-        st.write("### Forecast table (editable)")
-        edited_df = st.data_editor(
-            df[["date", "mean", "lo", "hi", "model", "confidence", "adjusted_mean"]],
-            num_rows="dynamic",
-            use_container_width=True,
-            key="data_editor",
-        )
-        # Plot original and adjusted forecasts
-        base = alt.Chart(edited_df).encode(x="date:T")
-        line_original = base.mark_line(color="steelblue").encode(y="mean:Q", tooltip=["date:T", "mean:Q"])
-        line_adjusted = base.mark_line(color="firebrick").encode(y="adjusted_mean:Q", tooltip=["date:T", "adjusted_mean:Q"])
-        band = base.mark_area(opacity=0.2, color="gray").encode(y="lo:Q", y2="hi:Q")
-        chart = (band + line_original + line_adjusted).properties(width=700, height=300, title=f"Forecast for {sku}")
-        st.altair_chart(chart, use_container_width=True)
-    except Exception as e:
-        st.error(f"Failed to retrieve forecast: {e}")
+        with st.spinner("Fetching forecast from API…"):
+            payload = _fetch_forecast(sku, int(horizon))
+    except requests.HTTPError as exc:
+        detail = exc.response.json().get("detail") if exc.response is not None else str(exc)
+        st.error(f"API error: {detail}")
+    except Exception as exc:  # pragma: no cover - UI fallback
+        st.error(f"Failed to retrieve forecast: {exc}")
+    else:
+        forecast_df = pd.DataFrame(payload.get("forecast", []))
+        if forecast_df.empty:
+            st.warning("Forecast response was empty. Please verify the SKU ID and horizon.")
+        else:
+            forecast_df["date"] = pd.to_datetime(forecast_df["date"])
+            st.write("### Forecast overview")
+            st.dataframe(
+                forecast_df[["date", "mean", "lo", "hi", "confidence", "model"]].rename(
+                    columns={"mean": "mean_units", "lo": "lower", "hi": "upper"}
+                ),
+                use_container_width=True,
+            )
+
+            base = alt.Chart(forecast_df).encode(x="date:T")
+            band = base.mark_area(opacity=0.2, color="steelblue").encode(y="lo:Q", y2="hi:Q")
+            line = base.mark_line(color="#1f77b4").encode(y="mean:Q")
+            chart = (band + line).properties(
+                width="container",
+                height=320,
+                title=f"Forecast horizon for {payload['sku_id']} ({payload['horizon_days']} days)",
+            )
+            st.altair_chart(chart, use_container_width=True)
+
+            st.info(
+                "Forecasts are generated using a smoothed moving-average baseline with calibrated prediction intervals."
+            )

--- a/frontend/pages/3_Recommendations.py
+++ b/frontend/pages/3_Recommendations.py
@@ -1,56 +1,71 @@
-"""
-Recommendations page for procurement planning.
+"""Streamlit page for procurement recommendations."""
 
-This page allows users to request a reorder recommendation for a SKU
-and display the suggested reorder point and quantity.  It also
-generates a simple explanation of the recommendation.
-"""
+from __future__ import annotations
 
 import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pandas as pd
 import requests
 import streamlit as st
-import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from backend.app.services.llm_service import explain_recommendation  # type: ignore  # noqa: E402
 
 API_URL = os.getenv("API_URL", "http://localhost:8000/api/v1")
 
-st.title("📦 Recommendations")
 
-st.write(
-    "Generate purchasing recommendations based on demand forecasts and guardrails. "
-    "Use this page to decide whether to place an order, and to understand the reasoning behind the suggestion."
-)
+def _fetch_recommendations(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    response = requests.post(
+        f"{API_URL}/procure/recommendations",
+        json=payload,
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+st.title("📦 Recommendations")
+st.caption("Compute EOQ/ROP-based reorder guidance backed by forecasting guardrails.")
 
 with st.form(key="recommend_form"):
     sku = st.text_input("SKU ID", value="HOBBIES_1_001")
-    horizon = st.number_input("Horizon (days)", min_value=1, max_value=90, value=28, step=1)
+    horizon = st.number_input("Horizon (days)", min_value=7, max_value=90, value=28, step=1)
+    lead_time = st.number_input("Assumed lead time (days)", min_value=1, max_value=60, value=7, step=1)
     submitted = st.form_submit_button("Get recommendation")
 
 if submitted:
+    body = {
+        "sku_id": sku,
+        "horizon_days": int(horizon),
+        "context": {"lead_time_days": int(lead_time)},
+    }
     try:
-        with st.spinner("Computing recommendation…"):
-            resp = requests.post(
-                f"{API_URL}/procure/recommendations",
-                json={"sku_id": sku, "horizon_days": horizon},
-                timeout=30,
-            )
-            resp.raise_for_status()
-            recs = resp.json()
-        if not recs:
-            st.info("No recommendation available.")
+        with st.spinner("Requesting recommendation from API…"):
+            recommendations = _fetch_recommendations(body)
+    except requests.HTTPError as exc:
+        detail = exc.response.json().get("detail") if exc.response is not None else str(exc)
+        st.error(f"API error: {detail}")
+    except Exception as exc:  # pragma: no cover - UI fallback
+        st.error(f"Failed to compute recommendation: {exc}")
+    else:
+        if not recommendations:
+            st.info("No recommendation available for the requested SKU.")
         else:
-            df = pd.DataFrame(recs)
-            st.write("### Recommendation")
-            st.table(df)
-            # Generate a simple explanation without calling the LLM
-            rec = recs[0]
-            explanation = (
-                f"For SKU **{rec['sku_id']}**, the system recommends reordering **{rec['order_qty']}** units "
-                f"once the on‑hand inventory falls to **{rec['reorder_point']}** units. "
-                f"This suggestion aims to maintain service levels while respecting cash constraints."
-            )
-            if rec.get("requires_approval"):
-                explanation += " Because the order quantity exceeds the auto‑approval limit, a human must approve this purchase."
-            st.markdown("### Explanation")
+            df = pd.DataFrame(recommendations)
+            st.write("### Recommended action")
+            st.dataframe(df, use_container_width=True)
+
+            requires_approval = any(rec.get("requires_approval") for rec in recommendations)
+            approval_status = "⚠️ Manual approval required" if requires_approval else "✅ Auto-approval"
+            st.subheader("Decision support")
+            st.write(approval_status)
+
+            explanation = explain_recommendation(body["context"], recommendations)
+            st.markdown("### Rationale")
             st.write(explanation)
-    except Exception as e:
-        st.error(f"Failed to compute recommendation: {e}")


### PR DESCRIPTION
## Summary
- replace the placeholder forecasting pipeline with a deterministic M5-aware SMA forecaster that enforces calendar bounds and confidence intervals
- implement EOQ/ROP procurement logic backed by inventory cost estimates, guardrail thresholds, and new API/UI wiring
- document M5 dataset placement, add backend unit tests, and surface the recommendations with contextual explanations in Streamlit

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68e0e913679883288870c9b22b97d34a