### PR TITLE
Implement EOQ/ROP procurement logic

### DIFF
--- a/backend/app/services/inventory_service.py
+++ b/backend/app/services/inventory_service.py
@@ -33,6 +33,22 @@ class InventoryService:
         self._load()
 
     # ------------------------------------------------------------------
+    def get_unit_cost(self, sku_id: str) -> float:
+        """Return an estimated unit cost for ``sku_id``."""
+
+        return float(self.estimate_unit_cost(sku_id))
+
+    # ------------------------------------------------------------------
+    def get_lead_time_days(self, sku_id: str) -> float:
+        """Return the best-known replenishment lead time in days."""
+
+        # The reference datasets do not expose lead-time information.  We
+        # therefore use a conservative 7-day placeholder which downstream
+        # services can override via context or configuration.
+        _ = sku_id  # Intentionally unused but keeps signature explicit.
+        return 7.0
+
+    # ------------------------------------------------------------------
     def _load(self) -> None:
         sales_path = os.path.join(self.data_root, "sales_train_validation.csv")
         prices_path = os.path.join(self.data_root, "sell_prices.csv")


### PR DESCRIPTION
## Summary
- add helpers to compute z-scores, EOQ, and ROP for procurement decisions
- implement EOQ/ROP-based reorder recommendations with GMROI and approval logic
- expose inventory service accessors for unit costs and lead-time defaults

## Testing
- python -m compileall backend/app/services/procurement_service.py backend/app/services/inventory_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e0ff2badcc8328b420fe6e9b300e03