### PR TITLE
Fix procurement approval service level guard

### DIFF
--- a/backend/app/services/procurement_service.py
+++ b/backend/app/services/procurement_service.py
@@ -201,7 +201,7 @@ class ProcurementService:
         requires_approval = (
             total_spend > self.auto_approval_limit
             or gmroi_delta < self.gmroi_min
-            or forecast_confidence < self.min_service_level
+            or service_level < self.min_service_level
         )
 
         confidence = max(min(forecast_confidence, 0.99), 0.01)


### PR DESCRIPTION
## Summary
- add helpers to compute z-scores, EOQ, and ROP for procurement decisions
- implement EOQ/ROP-based reorder recommendations with GMROI and approval logic
- expose inventory service accessors for unit costs and lead-time defaults
- enforce the configured minimum service level when determining auto-approval requirements

## Testing
- python -m compileall backend/app/services/procurement_service.py backend/app/services/inventory_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e6528fea9c832896c2c2ddfd365a73