### PR TITLE
Handle missing inventory datasets during SKU validation

### DIFF
--- a/backend/app/api/v1/forecasts.py
+++ b/backend/app/api/v1/forecasts.py
@@ -33,6 +33,16 @@ def _validate_sku(sku_id: str) -> None:
 
     has_sku: Callable[[str], bool]
     has_sku = getattr(_inventory_service, "has_sku", _inventory_service.sku_exists)
+    if getattr(_inventory_service, "sales_df", None) is None:
+        LOGGER.error("Inventory datasets missing while validating forecast request for sku_id=%s", sku_id)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=
+            _error_payload(
+                "data_unavailable",
+                "Required dataset files are missing. Please upload the M5 datasets and retry.",
+            ),
+        )
     if not has_sku(sku_id):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/app/api/v1/procure.py
+++ b/backend/app/api/v1/procure.py
@@ -36,6 +36,19 @@ def _validate_sku(sku_id: str) -> None:
     """Ensure the SKU exists before processing recommendations."""
 
     has_sku = getattr(_inventory_service, "has_sku", _inventory_service.sku_exists)
+    if getattr(_inventory_service, "sales_df", None) is None:
+        LOGGER.error(
+            "Inventory datasets missing while validating procurement request for sku_id=%s",
+            sku_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=
+            _error_payload(
+                "data_unavailable",
+                "Required dataset files are missing. Please upload the M5 datasets and retry.",
+            ),
+        )
     if not has_sku(sku_id):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,


### PR DESCRIPTION
## Summary
- raise a 503 data_unavailable error when forecast SKU validation detects missing inventory datasets
- apply the same dataset availability guard to procurement SKU validation to avoid masking outages

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e65290108c8328932a30cdda152b64