### PR TITLE
Address Codex review feedback for procurement approval confidence

### DIFF
--- a/backend/app/services/procurement_service.py
+++ b/backend/app/services/procurement_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import math
 import os
+from numbers import Real
 from typing import Any, Dict, Iterable, List, Tuple
 
 import numpy as np
@@ -195,9 +196,20 @@ class ProcurementService:
 
         get_inventory = getattr(self.inventory_service, "get_current_inventory", None)
         current_inventory = get_inventory(sku_id) if callable(get_inventory) else 0
-        if not isinstance(current_inventory, (int, float)):
-            current_inventory = 0
-        inventory_units_proxy = max(current_inventory, 1)
+        if isinstance(current_inventory, Real):
+            current_inventory = float(current_inventory)
+        else:
+            try:
+                current_inventory = float(current_inventory)
+            except (TypeError, ValueError):
+                LOGGER.warning(
+                    "Inventory service returned non-numeric inventory for %s; defaulting to 0",
+                    sku_id,
+                )
+                current_inventory = 0.0
+        if not math.isfinite(current_inventory) or current_inventory < 0:
+            current_inventory = 0.0
+        inventory_units_proxy = max(current_inventory, 1.0)
         get_latest_price = getattr(self.inventory_service, "get_latest_price", None)
         latest_price = get_latest_price(sku_id) if callable(get_latest_price) else None
         sell_price = None if latest_price is None else float(latest_price.sell_price)


### PR DESCRIPTION
## Summary
- restore the confidence cap when recommendations require manual approval
- add defensive fallbacks around inventory service lookups to tolerate simplified stubs
- accept numpy-based inventory counts while sanitizing invalid values

## Testing
- pytest backend/tests/test_procurement.py::test_requires_approval_when_spend_exceeds_limit

------
https://chatgpt.com/codex/tasks/task_e_68e658f886c08328a262114ba6a96644